### PR TITLE
Search issues support

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -68,3 +68,30 @@ module.exports = (robot, scripts) ->
           else
             msg.reply "Error from GitHub API: #{err.body.message}"
             return err
+
+    searchIssues: (msg, query, repo) ->
+      token = githubTokenForUser msg
+      if token?
+        client = github.client token
+        ghQueryString = query
+        if repo.endsWith "/undefined"
+          ghQueryString += "+user:#{repo.replace("/undefined", "")}"
+        else
+          ghQueryString += "+repo:#{repo}"
+        queryObj =
+          q: ghQueryString
+          sort: "created"
+          order: "asc"
+        client.search().issues queryObj, (err, data, headers) ->
+          unless err?
+            robot.logger.info data
+            reply = "Found #{data.total_count} issue"
+            reply += if data.total_count != 1 then "s\n" else "\n"
+            if data.items
+              for issue in data.items
+                reply += "##{issue.number} #{issue.title}\n"
+                reply += "#{issue.html_url}\n"
+            msg.reply reply
+          else
+            msg.reply "Error from GitHub API: #{err.body.message}"
+            return err

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Hubot interface for GitHub issues",
   "version": "0.0.4",
   "author": "@benwtr",
+  "contributors": [
+    "Tommi Laukkanen (https://github.com/tlaukkanen)"
+  ],
   "license": "MIT",
   "keywords": [
     "hubot",
@@ -21,7 +24,7 @@
   "dependencies": {
     "coffee-script": "~1.6",
     "hubot-gh-token": "0.0.1",
-    "octonode": "^0.7.6"
+    "octonode": "^0.9.0"
   },
   "devDependencies": {
     "chai": "*",

--- a/src/gh-issues.coffee
+++ b/src/gh-issues.coffee
@@ -14,6 +14,7 @@
 #   hubot github show issue #<issue_number> (in (<owner>/)<repo>)
 #   hubot github close issue #<issue_number> (in (<owner>/)<repo>)
 #   hubot github comment issue #<issue_number> (in (<owner>/)<repo>) "<comment>"
+#   hubot github search issues "<query>" (in "(<owner>/)<repo>") (with labels "<label1>,<label2>,..") - Search issues
 #
 # Author:
 #   @benwtr
@@ -65,3 +66,13 @@ module.exports = (robot) ->
       "#{DEFAULT_OWNER}/#{DEFAULT_REPO}"
     comment = msg.match[4]
     robot.ghissues.commentOnIssue msg, comment, id, repo
+
+  robot.respond /(?:github|gh) search issues "([^"]+)"(?: in "([\w\d-_]+)(?:\/([\w\d-_]+))?")?$/i, id: 'gh-issues.search', (msg) ->
+    query = msg.match[1]
+    repo = if msg.match[2]? and msg.match[3]?
+      "#{msg.match[2]}/#{msg.match[3]}"
+    else if msg.match[2]?
+      "#{DEFAULT_OWNER}/#{msg.match[2]}"
+    else
+      "#{DEFAULT_OWNER}/#{DEFAULT_REPO}"
+    robot.ghissues.searchIssues msg, query, repo


### PR DESCRIPTION
Adds basic issue search support. With this you can search issues with:
> hubot github search  issues "keyword" (in "org/repo")

Hubot will list issues along with their html links:
> Found 2 issues
> #123 Some issue
> https://github.com/org/repo/issues/123
> #124 Other issue
> https://github.com/org/repo/issues/124